### PR TITLE
Explicit log domains

### DIFF
--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -4,7 +4,7 @@
 /// @copyright Copyright (c) 2021 Christopher White
 ///
 /// Terminology: messages are logged if the "message level" is less than
-/// or equal to the "system level".
+/// or equal to the "domain level".
 ///
 /// There can be any number of log-message domains, each identified by an
 /// arbitrary non-empty string.  Strings starting with `" "` (a space) are
@@ -39,9 +39,8 @@
 /// The string we will use as a hash key for this file's messages
 static const std::string SMALLCXX_LOG_DOMAIN_NAME(SMALLCXX_LOG_DOMAIN);
 
-// Log levels.  Errors are always visible; other messages can be suppressed
-// by calling setLogLevel().
-// @warning Keep this in sync with g_levelnames in logging.cpp!
+/// @brief Log levels.
+/// @warning Keep this in sync with g_levelnames in logging.cpp!
 enum LogLevel {
     LOG_SILENT, ///< Nothing prints
     LOG_ERROR,
@@ -133,14 +132,12 @@ void setLogLevel(LogLevel newLevel,
 /// Clip @p level to [LOG_SILENT]+[LOG_MIN, LOG_MAX].  A convenience function.
 LogLevel clipLogLevel(LogLevel level);
 
-/// Get the current log level
+/// Get the current log level for @p domain.
 LogLevel getLogLevel(const std::string& domain = SMALLCXX_DEFAULT_LOG_DOMAIN);
 
-/// Set the verbosity for all log domains based on $V.  If $V exists and
-/// is a decimal >=1, the system level is set to INFO + $V (e.g., 1 = LOG_DEBUG,
-/// 2 = LOG_LOG).
-/// @note Does not set verbosities for all log domains.
-/// @todo implement a `GST_DEBUG`-style log-level selector.
+/// Set the verbosity for all log domains based on `$V`.  If `$V` exists and
+/// is a decimal >=1, the domain level is set to `INFO + $V`
+/// (e.g., 1 = LOG_DEBUG, 2 = LOG_LOG).
 /// @warning Must be called before any messages are logged if it is to affect
 ///     all log domains.
 ///

--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -1,7 +1,7 @@
 /// @file logging.hpp
 /// @brief Header for logging library
 /// @author Christopher White <cxwembedded@gmail.com>
-/// @copyright Copyright (c) 2021 Christopher White
+/// @copyright Copyright (c) 2021--2022 Christopher White
 ///
 /// Terminology: messages are logged if the "message level" is less than
 /// or equal to the "domain level".

--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -7,9 +7,10 @@
 /// or equal to the "system level".
 ///
 /// There can be any number of log-message domains, each identified by an
-/// arbitrary string.  Strings starting with `" "` (a space) are reserved for
-/// use by smallcxx/logging.  To define your own domain for messages in
-/// a source file:
+/// arbitrary non-empty string.  Strings starting with `" "` (a space) are
+/// reserved for use by smallcxx/logging.  To define your own domain for
+/// messages in a source file, `#define` @c SMALLCXX_LOG_DOMAIN to a string
+/// constant before you `#include` this file.  For example:
 ///
 /// ```
 /// #define SMALLCXX_LOG_DOMAIN "myDomain"
@@ -28,9 +29,8 @@
 #include <stdio.h>
 #include <string>
 
-/// Default log domain.  To use your own domain, `#define`
-/// @c SMALLCXX_LOG_DOMAIN to a string constant before `#includ`ing this file
-#define SMALLCXX_DEFAULT_LOG_DOMAIN ""
+/// Default log domain.
+#define SMALLCXX_DEFAULT_LOG_DOMAIN "default"
 
 #ifndef SMALLCXX_LOG_DOMAIN
 #define SMALLCXX_LOG_DOMAIN SMALLCXX_DEFAULT_LOG_DOMAIN

--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -7,15 +7,26 @@
 /// or equal to the "domain level".
 ///
 /// There can be any number of log-message domains, each identified by an
-/// arbitrary non-empty string.  Strings starting with `" "` (a space) are
-/// reserved for use by smallcxx/logging.  To define your own domain for
-/// messages in a source file, `#define` @c SMALLCXX_LOG_DOMAIN to a string
-/// constant before you `#include` this file.  For example:
+/// arbitrary non-empty string.  (However, strings starting with `" "` (a
+/// space) are reserved for use by smallcxx/logging.)
+///
+/// To define your own domain for messages in a source file, `#define` @c
+/// SMALLCXX_LOG_DOMAIN to a string constant before you `#include` this file.
+/// For example:
 ///
 /// ```
 /// #define SMALLCXX_LOG_DOMAIN "myDomain"
 /// #include <smallcxx/logging.hpp>
 /// ```
+///
+/// #### Special domains
+///
+/// - As noted above, domains starting with a space character are reserved.
+///   setLogLevel() will refuse to set the level for such a domain.
+/// - Domains starting with a plus sign (`+`) are "explicit" domains: they
+///   are silent unless you expressly set a value for them.
+///
+/// #### Thanks
 ///
 /// This logging library is inspired by (but not copied from):
 /// - [Loguru](https://github.com/emilk/loguru) by
@@ -138,16 +149,18 @@ LogLevel getLogLevel(const std::string& domain = SMALLCXX_DEFAULT_LOG_DOMAIN);
 /// Set the verbosity for all log domains based on `$V`.  If `$V` exists and
 /// is a decimal >=1, the domain level is set to `INFO + $V`
 /// (e.g., 1 = LOG_DEBUG, 2 = LOG_LOG).
-/// @warning Must be called before any messages are logged if it is to affect
-///     all log domains.
 ///
 /// @param[in]  detailEnvVarName - if given, non-NULL, and nonempty, the name
 ///     of a GStreamer-style log-level variable to be used instead of `$V` if
 ///     the given variable exists.
 void setVerbosityFromEnvironment(const char *detailEnvVarName = nullptr);
 
-/// Set all levels to silent.  Does not lock them there; they can be changed
-/// afterwards by calling setLogLevel() or setVerbosityFromEnvironment().
+/// Set all domains to silent, **except** for reserved domains (starting with
+/// #DOMAIN_SIGIL_RESERVED).  Reserved domains are reset to LOG_INFO.
+///
+/// Calling this function does not lock the levels.  They can be
+/// changed afterwards by calling setLogLevel() or
+/// setVerbosityFromEnvironment().
 void silenceLog();
 
 #endif // LOGGING_HPP_

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -242,7 +242,9 @@ clipLogLevel(LogLevel level)
 void
 setLogLevel(LogLevel newLevel, const std::string& domain)
 {
-    if(!domain.empty() && domain[0] == ' ') {
+    throw_assert(!domain.empty());
+
+    if(domain[0] == ' ') {
         throw domain_error("Logging domains starting with a space are reserved");
     }
 
@@ -254,7 +256,7 @@ setLogLevel(LogLevel newLevel, const std::string& domain)
     if( (newLevel == LOG_PRINT) || (newLevel == LOG_PRINTERR) ) {
         throw domain_error(STR_OF
                            << "Ignoring attempt to set invalid log level for "
-                           << (domain.empty() ? "default domain" : domain));
+                           << domain);
     }
 
     newLevel = clipLogLevel(newLevel);
@@ -265,6 +267,7 @@ setLogLevel(LogLevel newLevel, const std::string& domain)
 LogLevel
 getLogLevel(const std::string& domain)
 {
+    throw_assert(!domain.empty());
     return g_currSystemLevels[domain].l;
 }
 
@@ -310,9 +313,12 @@ setLevelFromStrings(const std::string& domain, const std::string& value)
 
     if(domain == "*") {
         LogLevelWithDefault::defaultLevel = level;
-    } else {
+    } else if(!domain.empty()) {
         setLogLevel(level, domain);
+    } else {
+        throw domain_error("Invalid logging domain");
     }
+
 }
 
 /// @return True if @p detailEnvVarName was parsed successfully

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -60,7 +60,7 @@ struct LogLevelWithDefault {
 LogLevel LogLevelWithDefault::defaultLevel = LOG_INFO;
 
 
-/// Type to hold current system log levels.
+/// Type to hold current domain levels.
 /// Myers singleton since we need it during startup.
 struct LogLevelHolder {
     using MapType = unordered_map<string, LogLevelWithDefault>;
@@ -176,24 +176,22 @@ vlogMessage(const std::string& domain,
                             pidcolor, pid, bodycolor, levelname, file, line, function);
 
     if(charsWritten <= 0 || (size_t)charsWritten >= sizeof(preamble)) {
-        // *INDENT-OFF*
+        // LCOV_EXCL_START
         // Uncovered --- I don't know any way to cause this to happen so I can test it
-        const char msg[] = "Dropped log message (preamble error)\n";    // LCOV_EXCL_START
+        const char msg[] = "Dropped log message (preamble error)\n";
         ignore_return_value = write(LOG_FD, msg, sizeof(msg));
         return;
-        // *INDENT-ON*
     } // LCOV_EXCL_STOP
 
     // The user's message
     charsWritten = vsnprintf(msg, sizeof(msg), format, args);
 
     if(charsWritten <= 0) { // accept message truncation
-        // *INDENT-OFF*
+        // LCOV_EXCL_START
         // Uncovered; same reason as above
-        const char msg[] = "Dropped log message (message error)\n"; // LCOV_EXCL_START
+        const char msg[] = "Dropped log message (message error)\n";
         ignore_return_value = write(LOG_FD, msg, sizeof(msg));
         return;
-        // *INDENT-ON*
     } // LCOV_EXCL_STOP
 
     chomp(msg);
@@ -205,12 +203,11 @@ vlogMessage(const std::string& domain,
                             roomForMessage, msg, endcolor);
 
     if(charsWritten <= 0) {
-        // *INDENT-OFF*
+        // LCOV_EXCL_START
         // Uncovered; same reason as above
-        const char msg[] = "Dropped log message (assembly error)\n";    // LCOV_EXCL_START
+        const char msg[] = "Dropped log message (assembly error)\n";
         ignore_return_value = write(LOG_FD, msg, sizeof(msg));
         return;
-        // *INDENT-ON*
     } // LCOV_EXCL_STOP
 
     ignore_return_value = write(LOG_FD, whole, charsWritten);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -38,6 +38,7 @@ testprograms = \
 alsocompile = \
 	log-debug-message-s \
 	silent-s \
+	varying-log-s \
 	$(EOL)
 
 # Data files needed by the tests.

--- a/t/common.sh.in
+++ b/t/common.sh.in
@@ -9,10 +9,11 @@ set -euo pipefail
 
 # Permit core dumps
 ulimit -c unlimited
-sysctl kernel.core_pattern
+sysctl kernel.core_pattern || true
 
 # Directories
 export pgmdir="@abs_top_builddir@/src"
+export tpgmdir="@abs_top_builddir@/t"
 export here
 here="$(cd "$(dirname "$0")" ; pwd)"
 

--- a/t/log-explicit-domain-s.cpp
+++ b/t/log-explicit-domain-s.cpp
@@ -1,0 +1,19 @@
+/// @file log-explicit-domain-s.cpp
+/// @brief Helper used by t/logging-t.sh
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2022 Christopher White
+
+/// Log domain.  This is an explicit domain, so does not participate in '*:lev'.
+#define SMALLCXX_LOG_DOMAIN "+fruit"
+
+#include "smallcxx/logging.hpp"
+
+using namespace std;
+
+int
+main()
+{
+    setVerbosityFromEnvironment("LOG_LEVELS");
+    LOG_F(DEBUG, "avocado");
+    return 0;
+}

--- a/t/logging-t.sh
+++ b/t/logging-t.sh
@@ -18,7 +18,21 @@ main() {
     V=10 "$tpgmdir/log-debug-message-s" &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
 
+    # Varying defaults
+
+    LOG_LEVELS='*:3' "$tpgmdir/varying-log-s" &> "$tmpfile"
+    has-line-matching 'error1' "$tmpfile"
+    has-line-matching 'warning1' "$tmpfile"
+    has-line-matching 'fixme1' "$tmpfile"
+    has-line-matching 'info1' "$tmpfile"
+
+    has-line-matching 'error1' "$tmpfile"
+    has-line-matching 'warning1' "$tmpfile"
+    has-line-matching 'fixme1' "$tmpfile"
+    does-not-contain 'info1' "$tmpfile"     # Suppressed by change in default
+
     # Explicit log levels.  log-explicit-domain logs "avocado" @ DEBUG to +fruit
+
     LOG_LEVELS='*:10' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     does-not-contain 'avocado' "$tmpfile"
 

--- a/t/logging-t.sh
+++ b/t/logging-t.sh
@@ -7,6 +7,8 @@ main() {
     tmpfile="$(mktemp)"
     trap 'rm -f "$tmpfile"' EXIT
 
+    # Basics
+
     unset V
     unset LOG_LEVELS
 
@@ -15,6 +17,22 @@ main() {
 
     V=10 "$here/log-debug-message-s" &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
+
+    # Explicit log levels.  log-explicit-domain logs "avocado" @ DEBUG to +fruit
+    LOG_LEVELS='*:10' "$here"/log-explicit-domain-s &> "$tmpfile"
+    does-not-contain 'avocado' "$tmpfile"
+
+    LOG_LEVELS='*:0,+fruit:10' "$here"/log-explicit-domain-s &> "$tmpfile"
+    has-line-matching 'avocado' "$tmpfile"
+
+    LOG_LEVELS='*:0,+fruit:5' "$here"/log-explicit-domain-s &> "$tmpfile"
+    has-line-matching 'avocado' "$tmpfile"
+
+    LOG_LEVELS='+fruit:5,*:0' "$here"/log-explicit-domain-s &> "$tmpfile"
+    has-line-matching 'avocado' "$tmpfile"
+
+    LOG_LEVELS='*:0,+fruit:4' "$here"/log-explicit-domain-s &> "$tmpfile"
+    does-not-contain 'avocado' "$tmpfile"
 
     report-and-exit 0
 }

--- a/t/logging-t.sh
+++ b/t/logging-t.sh
@@ -12,26 +12,26 @@ main() {
     unset V
     unset LOG_LEVELS
 
-    "$here/log-debug-message-s" &> "$tmpfile"
+    "$tpgmdir/log-debug-message-s" &> "$tmpfile"
     does-not-contain 'avocado' "$tmpfile"
 
-    V=10 "$here/log-debug-message-s" &> "$tmpfile"
+    V=10 "$tpgmdir/log-debug-message-s" &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
 
     # Explicit log levels.  log-explicit-domain logs "avocado" @ DEBUG to +fruit
-    LOG_LEVELS='*:10' "$here"/log-explicit-domain-s &> "$tmpfile"
+    LOG_LEVELS='*:10' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     does-not-contain 'avocado' "$tmpfile"
 
-    LOG_LEVELS='*:0,+fruit:10' "$here"/log-explicit-domain-s &> "$tmpfile"
+    LOG_LEVELS='*:0,+fruit:10' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
 
-    LOG_LEVELS='*:0,+fruit:5' "$here"/log-explicit-domain-s &> "$tmpfile"
+    LOG_LEVELS='*:0,+fruit:5' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
 
-    LOG_LEVELS='+fruit:5,*:0' "$here"/log-explicit-domain-s &> "$tmpfile"
+    LOG_LEVELS='+fruit:5,*:0' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     has-line-matching 'avocado' "$tmpfile"
 
-    LOG_LEVELS='*:0,+fruit:4' "$here"/log-explicit-domain-s &> "$tmpfile"
+    LOG_LEVELS='*:0,+fruit:4' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     does-not-contain 'avocado' "$tmpfile"
 
     report-and-exit 0

--- a/t/silent-t.sh
+++ b/t/silent-t.sh
@@ -9,7 +9,7 @@ trap 'rm -f "$tmpfile"' EXIT
 unset V
 unset LOG_LEVELS
 
-"$here/silent-s" &> "$tmpfile"
+"$tpgmdir/silent-s" &> "$tmpfile"
 does-not-contain 'error' "$tmpfile"
 does-not-contain 'warning' "$tmpfile"
 does-not-contain 'fixme' "$tmpfile"

--- a/t/varying-log-s.cpp
+++ b/t/varying-log-s.cpp
@@ -1,0 +1,39 @@
+/// @file t/varying-log-s.cpp
+/// @brief Log, but change the default halfway through.
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2022 Christopher White
+
+#define SMALLCXX_LOG_DOMAIN "lev"
+#include "smallcxx/logging.hpp"
+
+using namespace std;
+
+int
+main()
+{
+
+    LOG_F(ERROR, "error1");
+    LOG_F(WARNING, "warning1");
+    LOG_F(FIXME, "fixme1");
+    LOG_F(INFO, "info1");
+    LOG_F(DEBUG, "debug1");
+    LOG_F(LOG, "log1");
+    LOG_F(TRACE, "trace1");
+    LOG_F(PEEK, "peek1");
+    LOG_F(SNOOP, "snoop1");
+
+    // Change the default, if $LOG_LEVELS includes a `*:N` term
+    setVerbosityFromEnvironment("LOG_LEVELS");
+
+    LOG_F(ERROR, "error2");
+    LOG_F(WARNING, "warning2");
+    LOG_F(FIXME, "fixme2");
+    LOG_F(INFO, "info2");
+    LOG_F(DEBUG, "debug2");
+    LOG_F(LOG, "log2");
+    LOG_F(TRACE, "trace2");
+    LOG_F(PEEK, "peek2");
+    LOG_F(SNOOP, "snoop2");
+
+    return 0;
+}


### PR DESCRIPTION
- Domains starting with `+` do not get levels from `*:N` assignments.  Closes #16.
- The log level of a domain is not captured at the time of first log to that domain.  If the default changes up and down over the course of a run, the level of any unassigned domain will also.