### PR TITLE
globstari: throw if needle is empty

### DIFF
--- a/include/smallcxx/common.hpp
+++ b/include/smallcxx/common.hpp
@@ -12,12 +12,24 @@
 #define ARRAY_SIZE(x) \
     (sizeof(x) / sizeof(x[0]))
 
+namespace smallcxx
+{
+
+/// The assertion thrown by throw_assert().
+class AssertionFailure: public std::logic_error
+{
+public:
+    using std::logic_error::logic_error;
+};
+
+}
+
 /// Throw a message indicating an assertion failed, iff @p cond is false.
 #define throw_assert(cond) \
     do { \
         const bool _ok = (cond); \
         if(!_ok) { \
-            throw std::runtime_error(STR_OF << __FILE__ << ':' << __LINE__ \
+            throw smallcxx::AssertionFailure(STR_OF << __FILE__ << ':' << __LINE__ \
                     << ": failure in assertion " << #cond); \
         } \
     } while(0)

--- a/include/smallcxx/globstari.hpp
+++ b/include/smallcxx/globstari.hpp
@@ -380,6 +380,7 @@ public:
 /// @param[in]  basePath - where to start.
 /// @param[in]  needle - EditorConfig-style globs indicating the files
 ///     to find.  These are with respect to @p basePath.
+///     **Note** @p needle must not be empty.
 /// @param[in]  maxDepth - maximum recursion depth.  -1 for unlimited.
 ///
 /// Bear in mind:

--- a/src/globstari-traverse.cpp
+++ b/src/globstari-traverse.cpp
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <system_error>
 
+#include "smallcxx/common.hpp"
 #include "smallcxx/globstari.hpp"
 #include "smallcxx/logging.hpp"
 #include "smallcxx/string.hpp"
@@ -106,6 +107,14 @@ class Traverser
     bool traversed_;        ///< have we already been run?
 
 public:
+    /// Ctor.
+    /// @param[in]  fileTree - see globstari()
+    /// @param[in]  processEntry - see globstari()
+    /// @param[in]  basePath - see globstari()
+    /// @param[in]  needle - see globstari().
+    /// @param[in]  maxDepth - see globstari()
+    ///
+    /// @throws AssertionFailure if @p needle is empty.
     Traverser(IFileTree& fileTree, IProcessEntry& processEntry,
               const smallcxx::glob::Path& basePath,
               const std::vector<smallcxx::glob::Path>& needle,
@@ -114,6 +123,7 @@ public:
         : fileTree_(fileTree), maxDepth_(maxDepth), processEntry_(processEntry),
           traversed_(false)
     {
+        throw_assert(!needle.empty());
         smallcxx::glob::Path rootPath = fileTree_.canonicalize(basePath);
         needleMatcher_.addGlobs(needle,
                                 rootPath.back() == '/' ? rootPath : rootPath + "/");

--- a/t/globstari-basic-t.cpp
+++ b/t/globstari-basic-t.cpp
@@ -61,6 +61,12 @@ test_sanity()
     // FileTree and ProcessEntry instances can, in general, be used more than once
     globstari(fileTree, processEntry, "/", {"*"});
     reached();
+
+    // Empty needle is not allowed
+    throws_with_msg(
+        globstari(fileTree, processEntry, "/", {}),
+        "needle.empty"
+    );
 }
 
 /// @name Tests of disk globbing


### PR DESCRIPTION
Fixes #24.

Also, give throw_assert() its own exception.