### PR TITLE
Matcher::addGlob flexibility; $SMALLCXX_TEST_DEBUG; internal and test improvements

### DIFF
--- a/include/smallcxx/globstari.hpp
+++ b/include/smallcxx/globstari.hpp
@@ -164,7 +164,7 @@ public:
     /// addGlob(Path,Path).
     /// @param[in]  globs - the globs to add
     /// @param[in]  path - where each of the globs should be anchored.  Must be
-    ///     nonempty and end with a `/`.
+    ///     nonempty.  May end with `/` or not.
     /// @param[in]  delegate - The Matcher to delegate to for unknown results.
     ///     E.g., a parent ignore set.  Optional; default nullptr.
     Matcher(const std::initializer_list<smallcxx::glob::Path>& globs,

--- a/include/smallcxx/test.hpp
+++ b/include/smallcxx/test.hpp
@@ -47,7 +47,7 @@
 /// The name of an environment variable used for detailed log-level control.
 /// To support detailed control, define this to a string before including
 /// this file.  `$V` is always supported.
-#define TEST_DETAIL_ENV_VAR_NAME
+#define TEST_DETAIL_ENV_VAR_NAME "SMALLCXX_TEST_DEBUG"
 
 #endif
 

--- a/src/globstari-matcher.cpp
+++ b/src/globstari-matcher.cpp
@@ -82,13 +82,17 @@ void
 Matcher::addGlob(const smallcxx::glob::Path& glob,
                  const smallcxx::glob::Path& path)
 {
-
-    if(path.empty() || *path.crbegin() != '/') {
-        throw domain_error("Matcher::addGlob: path must be nonempty and end with /");
+    if(path.empty()) {
+        throw domain_error("Matcher::addGlob: path must be nonempty");
     }
 
     // Strip trailing slash.  TODO handle this in a cleaner way.
-    const auto pathNoSlash = path.substr(0, path.size() - 1);
+    smallcxx::glob::Path pathNoSlash;
+    if(*path.crbegin() == '/') {
+        pathNoSlash = path.substr(0, path.size() - 1);
+    } else {
+        pathNoSlash = path;
+    }
 
     Polarity polarity = (glob[0] == '!') ? Polarity::Exclude : Polarity::Include;
 

--- a/src/globstari-traverse.cpp
+++ b/src/globstari-traverse.cpp
@@ -125,8 +125,7 @@ public:
     {
         throw_unless(!needle.empty());
         smallcxx::glob::Path rootPath = fileTree_.canonicalize(basePath);
-        needleMatcher_.addGlobs(needle,
-                                rootPath.back() == '/' ? rootPath : rootPath + "/");
+        needleMatcher_.addGlobs(needle, rootPath);
         needleMatcher_.finalize();
 
         // Prime the pump.  Note: the ignores start out empty, so this

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -43,6 +43,7 @@ alsocompile = \
 	log-debug-message-s \
 	log-explicit-domain-s \
 	silent-s \
+	testfile-s \
 	varying-log-s \
 	$(EOL)
 

--- a/t/globstari-basic-t.cpp
+++ b/t/globstari-basic-t.cpp
@@ -18,6 +18,9 @@ using smallcxx::glob::Path;
 class TestFileTreeSanity: public IFileTree
 {
 public:
+    // LCOV_EXCL_START - since TestProcessEntrySanity returns Stop on the
+    // root dir, readDir() is never called.  Since there are no entries,
+    // readFile is never called.
     std::vector< std::shared_ptr<Entry> >
     readDir(const Path& dirPath) override
     {
@@ -29,6 +32,7 @@ public:
     {
         return "";
     }
+    // LCOV_EXCL_STOP
 
     Path
     canonicalize(const Path& path) const override

--- a/t/globstari-matcher-t.cpp
+++ b/t/globstari-matcher-t.cpp
@@ -292,6 +292,13 @@ test_path_namestart()
     ok(!m2.contains("/file.txt"));
     ok(!m2.contains("/file1.txt"));
     ok(!m2.contains("/filez.txt"));
+
+    // Matcher::addGlob can accept paths without a trailing slash
+    Matcher m3;
+    m3.addGlob("file*", "/foo");
+    m3.finalize();
+    ok(m3.contains("/foo/file"));
+    ok(!m3.contains("/file"));
 }
 
 // }}}1

--- a/t/logging-t.sh
+++ b/t/logging-t.sh
@@ -59,6 +59,16 @@ main() {
     LOG_LEVELS='*:0,+fruit:4' "$tpgmdir"/log-explicit-domain-s &> "$tmpfile"
     does-not-contain 'avocado' "$tmpfile"
 
+    # Default env var
+    unset SMALLCXX_TEST_DEBUG
+    "$tpgmdir/testfile-s" &> "$tmpfile"
+    has-line-matching 'All tests passed' "$tmpfile"
+    does-not-contain 'avocado' "$tmpfile"
+
+    SMALLCXX_TEST_DEBUG='*:6' "$tpgmdir/testfile-s" &> "$tmpfile"
+    has-line-matching 'All tests passed' "$tmpfile"
+    has-line-matching 'avocado' "$tmpfile"
+
     return 0
 }
 

--- a/t/testfile-s.cpp
+++ b/t/testfile-s.cpp
@@ -1,0 +1,20 @@
+/// @file t/testfile-s.cpp
+/// @brief A sample test file.  Used to test logging functions in test code.
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2022 Christopher White
+
+#include "smallcxx/logging.hpp"
+#include "smallcxx/test.hpp"
+
+TEST_FILE;
+
+void
+test_dummy()
+{
+    LOG_F(LOG, "avocado");
+    cmp_ok(1 + 1, ==, 2);
+}
+
+TEST_MAIN {
+    TEST_CASE(test_dummy);
+}


### PR DESCRIPTION
- Matcher::addGlob: accept paths without a trailing slash
- test.hpp: process `$SMALLCXX_TEST_DEBUG`
- globstari: internal code clarifications and bugfixes
- Add tests of TEST_MAIN and of default test-file logging-control env var
- test coverage: add exclusions