### PR TITLE
Add IProcessEntry::ignored() that receives ignored entries (#8)

### DIFF
--- a/include/smallcxx/globstari.hpp
+++ b/include/smallcxx/globstari.hpp
@@ -385,6 +385,17 @@ public:
     /// @return A ProcessStatus value
     virtual IProcessEntry::Status operator()(const std::shared_ptr<Entry>& entry) =
         0;
+
+    /// Process an ignored entry.  Default is a no-op.
+    /// This is just in case you are interested in ignored entries.
+    /// The entry can be a directory or a file.
+    ///
+    /// @note This function is called for all (and only) ignored entries in the
+    ///     tree.  This is not called for non-ignored entries that do not
+    ///     match any @c needle.
+    ///
+    /// @param[in]  entry - the entry
+    virtual void ignored(const std::shared_ptr<Entry>& entry);
 };
 
 /// Find files, inside the hierarchy accessible through @p fileTree,

--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -8,7 +8,8 @@
 ///
 /// There can be any number of log-message domains, each identified by an
 /// arbitrary non-empty string.  (However, strings starting with `" "` (a
-/// space) are reserved for use by smallcxx/logging.)
+/// space) are reserved for use by smallcxx/logging.)  The default domain
+/// is called `default`.
 ///
 /// To define your own domain for messages in a source file, `#define` @c
 /// SMALLCXX_LOG_DOMAIN to a string constant before you `#include` this file.
@@ -162,6 +163,7 @@ LogLevel getLogLevel(const std::string& domain = SMALLCXX_DEFAULT_LOG_DOMAIN);
 /// @param[in]  detailEnvVarName - if given, non-NULL, and nonempty, the name
 ///     of a GStreamer-style log-level variable to be used instead of `$V` if
 ///     the given variable exists.
+///     In the log-level variable, the default domain is `default`.
 void setVerbosityFromEnvironment(const char *detailEnvVarName = nullptr);
 
 /// Set all domains to silent, **except** for reserved domains (starting with

--- a/src/globstari-traverse.cpp
+++ b/src/globstari-traverse.cpp
@@ -4,6 +4,7 @@
 /// @author Christopher White <cxwembedded@gmail.com>
 /// @copyright Copyright (c) 2021--2022 Christopher White
 /// @todo permit matching only directories (trailing slash on globs)
+/// SPDX-License-Identifier: BSD-3-Clause
 
 #define SMALLCXX_LOG_DOMAIN "glob"
 
@@ -26,6 +27,11 @@ using smallcxx::glob::PathCheckResult;
 
 namespace smallcxx
 {
+
+void
+IProcessEntry::ignored(const std::shared_ptr<Entry>& entry)
+{
+}
 
 // === Internal classes ==================================================
 
@@ -200,6 +206,10 @@ Traverser::worker()
         if(item.ignores->contains(item.entry->canonPath)) {
             LOG_F(TRACE, "ignored %s --- skipping",
                   item.entry->canonPath.c_str());
+
+            // In case the client is interested
+            processEntry_.ignored(item.entry);
+
             continue;
         }
 


### PR DESCRIPTION
ignored() is called for each ignored entry.  Clients can choose to implement this if they want notification of ignored entries.  The default implementation is a no-op.

Fixes #8.