### PR TITLE
globstari: Add "don't .eignore this entry" flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,31 @@ AM_COND_IF([HAVE_GIT],
 )
 AC_MSG_RESULT([$git_working_dir])
 
+dnl === Feature control ===================================================
+dnl
+dnl Based on the vars above, enable or disable specific features.
+
+dnl globstari - enabled by default; requires pcre2
+AC_ARG_WITH([globstari],
+    AS_HELP_STRING([--without-globstari], [Disable globstari]))
+
+AS_IF(
+    [test "x$with_globstari" = "xno"],
+        [ build_globstari=0 ],    dnl Globstari is disabled
+    [test "$have_pcre2" = '1'],
+        [ build_globstari=1 ],    dnl Globstar is enabled and we have its deps
+    dnl else
+        [ dnl Globstari is enabled but we do NOT have its deps
+            build_globstari=0
+            AC_MSG_WARN([m4_join([ ], [globstari enabled but I couldn't],
+                        [find the required PCRE2 package.  Proceeding],
+                        [without globstari.])])
+        ]
+)
+AC_DEFINE_UNQUOTED([BUILD_GLOBSTARI],[$build_globstari],[Whether to build globstari])
+AC_SUBST([BUILD_GLOBSTARI])
+AM_CONDITIONAL([BUILD_GLOBSTARI], [test "$build_globstari" = '1'])
+
 dnl === Output ============================================================
 
 AC_CONFIG_FILES([
@@ -104,6 +129,14 @@ AC_CONFIG_FILES([
     t/Makefile
     t/common.sh
 ])
+
+AS_ECHO([])
+AS_BOX([Feature summary])
+AM_COND_IF([BUILD_GLOBSTARI],
+    [AS_ECHO(["AS_HELP_STRING([globstari],[yes])"])],
+    [AS_ECHO(["AS_HELP_STRING([globstari],[no])"])]
+)
+AS_ECHO([])
 
 dnl TODO
 dnl dnl Extra-dist all of `git ls-files`.  Only used from the top-level Makefile,

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,7 +13,6 @@ nobase_include_HEADERS = \
 
 # --- Optional modules ---
 
-# globstari
-if HAVE_PCRE2
+if BUILD_GLOBSTARI
 nobase_include_HEADERS += smallcxx/globstari.hpp
 endif

--- a/include/smallcxx/globstari.hpp
+++ b/include/smallcxx/globstari.hpp
@@ -264,6 +264,19 @@ enum class EntryType {
 struct Entry {
     EntryType ty;   ///< what type this represents
 
+    /// @name Ignore control
+    /// @{
+
+    /// Whether this entry was ignored.  From the globstari system to
+    /// client code.
+    bool ignored = false;
+
+    /// Process this entry even if it's ignored.  From client code to the
+    /// globstari system.
+    bool neverIgnore = false;
+
+    /// @}
+
 #if 0
     /// Path of the directory this Entry is in
     smallcxx::glob::Path dirPath;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,9 +14,7 @@ libsmallcxx_a_CXXFLAGS = -I$(top_srcdir)/include $(AM_CXXFLAGS)
 
 # --- Optional modules ---
 
-# globstari
-if HAVE_PCRE2
-
+if BUILD_GLOBSTARI
 libsmallcxx_a_SOURCES += \
 	globstari.cpp \
 	globstari-matcher.cpp \

--- a/src/globstari-traverse.cpp
+++ b/src/globstari-traverse.cpp
@@ -203,14 +203,17 @@ Traverser::worker()
         }
 
         // Check against the ignores we already have
-        if(item.ignores->contains(item.entry->canonPath)) {
+        item.entry->ignored = item.ignores->contains(item.entry->canonPath);
+        if(item.entry->ignored && !item.entry->neverIgnore) {
             LOG_F(TRACE, "ignored %s --- skipping",
                   item.entry->canonPath.c_str());
 
             // In case the client is interested
             processEntry_.ignored(item.entry);
-
             continue;
+        } else if(item.entry->ignored) {    // neverIgnore is true
+            LOG_F(TRACE, "proceeding with neverIgnore %s",
+                  item.entry->canonPath.c_str());
         }
 
         // Is it a hit?

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -61,6 +61,7 @@ if BUILD_GLOBSTARI
 testprograms += \
 	globstari-basic-t \
 	globstari-globset-t \
+	globstari-ignore-control-t \
 	globstari-matcher-t \
 	globstari-userdata-t \
 	$(EOL)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -57,8 +57,7 @@ testdatafiles = \
 
 # --- Tests for optional modules ---
 
-# globstari
-if HAVE_PCRE2
+if BUILD_GLOBSTARI
 testprograms += \
 	globstari-basic-t \
 	globstari-globset-t \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -65,6 +65,15 @@ testprograms += \
 	globstari-userdata-t \
 	$(EOL)
 endif
+
+# === Test helper library =================================================
+
+noinst_LIBRARIES = libtesthelpers.a
+libtesthelpers_a_SOURCES = \
+	testhelpers.cpp \
+	testhelpers.hpp \
+	$(EOL)
+
 ###########################################################################
 ###########################################################################
 
@@ -104,7 +113,12 @@ LOCAL_CFLAGS = \
 	$(PCRE2_CFLAGS) \
 	$(EOL)
 
-LDADD = $(top_builddir)/src/libsmallcxx.a $(PCRE2_LIBS) $(LIBRT_LIBS)
+LDADD = \
+	libtesthelpers.a \
+	$(top_builddir)/src/libsmallcxx.a \
+	$(PCRE2_LIBS) \
+	$(LIBRT_LIBS) \
+	$(EOL)
 
 check_PROGRAMS = \
 	$(testprograms) \

--- a/t/globstari-basic-t.cpp
+++ b/t/globstari-basic-t.cpp
@@ -9,6 +9,8 @@
 #include "smallcxx/globstari.hpp"
 #include "smallcxx/test.hpp"
 
+#include "testhelpers.hpp"
+
 TEST_FILE
 
 using namespace smallcxx;
@@ -76,55 +78,6 @@ test_sanity()
 
 /// @name Tests of disk globbing
 /// @{
-
-/// Test if @p got matches @p expectedPaths.
-static void
-compare_sequence(const set<glob::Path>& got,
-                 const vector<glob::Path>& expectedPaths,
-                 const char *func, const size_t line)
-{
-    // INFO log level so it will appear by default --- otherwise we don't know
-    // which test failed.
-    LOG_F(INFO, "Checking %s():%zu", func, line);
-
-    cmp_ok(got.size(), ==, expectedPaths.size());
-    size_t idx = 0;
-    for(auto it = got.cbegin();
-            (it != got.cend()) && (idx < expectedPaths.size());
-            ++it, ++idx) {
-        const auto& got = *it;
-        const auto& expected = expectedPaths[idx];
-        const auto where = got.rfind(expected);
-
-        LOG_F(SNOOP, "got [%s], expected [%s]", got.c_str(), expected.c_str());
-        cmp_ok(where, !=, got.npos);
-    }
-} // compare_sequence()
-
-/// Save filenames traversed.
-/// For testing globbing on disk.
-class SaveEntries: public IProcessEntry
-{
-public:
-    set<glob::Path> found;
-    set<glob::Path> ignoredPaths;
-
-    IProcessEntry::Status
-    operator()(const std::shared_ptr<Entry>& entry) override
-    {
-        LOG_F(TRACE, "Found %s", entry->canonPath.c_str());
-        found.insert(entry->canonPath);
-        return IProcessEntry::Status::Continue;
-    }
-
-    void
-    ignored(const std::shared_ptr<Entry>& entry) override
-    {
-        LOG_F(TRACE, "Found %s", entry->canonPath.c_str());
-        ignoredPaths.insert(entry->canonPath);
-    }
-
-}; // SaveEntries
 
 /// Tests using the contents of `t/globstari-basic-disk`.
 static void

--- a/t/globstari-ignore-control-t.cpp
+++ b/t/globstari-ignore-control-t.cpp
@@ -1,0 +1,92 @@
+/// @file t/globstari-ignore-control-t.cpp
+/// @brief Test ignore-control functions
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2021--2022 Christopher White
+
+#include "smallcxx/test.hpp"
+
+#include "testhelpers.hpp"
+
+TEST_FILE
+
+using namespace smallcxx;
+using namespace std;
+using smallcxx::glob::Path;
+
+/// An IFileTree that produces a virtual filesystem including an eignore file.
+class TestFileTreeIgnore: public IFileTree
+{
+public:
+    std::vector< std::shared_ptr<Entry> >
+    readDir(const Path& dirPath) override
+    {
+        std::vector< std::shared_ptr<Entry> > retval;
+
+        if(dirPath == "/") {
+            auto e = std::make_shared<Entry>(EntryType::File, "/.eignore");
+            retval.push_back(e);
+            e = std::make_shared<Entry>(EntryType::File, "/file");
+            retval.push_back(e);
+            e = std::make_shared<Entry>(EntryType::File, "/ignored");
+            retval.push_back(e);
+
+            // A force-unignored entry
+            e = std::make_shared<Entry>(EntryType::File, "/ignored-never");
+            e->neverIgnore = true;
+            retval.push_back(e);
+        }
+
+        return retval;
+    }
+
+    Bytes
+    readFile(const Path& path) override
+    {
+        if(path == "/.eignore") {
+            return "ignored*\n";
+        } else {
+            return "";
+        }
+    }
+
+    Path
+    canonicalize(const Path& path) const override
+    {
+        return path;
+    }
+}; // class TestFileTreeIgnore
+
+/// Test IProcessEntry::ignored()
+static void
+test_ignore_control()
+{
+    TestFileTreeIgnore fileTree;
+    SaveEntries processEntry;
+    reached();
+
+    globstari(fileTree, processEntry, "/", {"*"});
+    reached();
+
+    // dir contents: `/`, `/file`, `/.eignore`, `/ignored-never'
+    cmp_ok(processEntry.found.size(), ==, 4);
+
+    auto found = processEntry.foundEntries["/file"];
+    ok(!!found);
+    ok(!found->ignored);
+    found = processEntry.foundEntries["/ignored"];
+    ok(!found);
+    found = processEntry.foundEntries["/ignored-never"];
+    ok(!!found);
+    ok(found->ignored);
+    ok(found->neverIgnore);
+
+    found = processEntry.ignoredEntries["/file"];
+    ok(!found);
+    found = processEntry.ignoredEntries["/ignored"];
+    ok(!!found);
+    ok(found->ignored);
+}
+
+TEST_MAIN {
+    TEST_CASE(test_ignore_control);
+}

--- a/t/globstari-userdata-t.cpp
+++ b/t/globstari-userdata-t.cpp
@@ -9,6 +9,8 @@
 #include "smallcxx/globstari.hpp"
 #include "smallcxx/test.hpp"
 
+#include "testhelpers.hpp"
+
 TEST_FILE
 
 using namespace smallcxx;
@@ -57,24 +59,6 @@ public:
     }
 }; // class TestFileTreeUserdata
 
-/// Save files traversed.
-class SaveEntries: public IProcessEntry
-{
-public:
-    std::vector< std::shared_ptr<Entry> > found;
-
-    IProcessEntry::Status
-    operator()(const  std::shared_ptr<Entry>& entry) override
-    {
-        LOG_F(TRACE, "Found %s", entry->canonPath.c_str());
-        if(entry->ty == EntryType::File) {
-            found.push_back(entry);
-        }
-        return IProcessEntry::Status::Continue;
-    }
-
-}; // SaveEntries
-
 static void
 test_userdata()
 {
@@ -85,8 +69,8 @@ test_userdata()
     globstari(fileTree, processEntry, "/", {"*"});
     reached();
 
-    cmp_ok(processEntry.found.size(), ==, 1);
-    const auto found = processEntry.found[0];
+    cmp_ok(processEntry.found.size(), ==, 2);
+    const auto found = processEntry.foundEntries["/file"];
     ok(!!found);
     const auto fatEntry = dynamic_pointer_cast<FatEntry>(found);
     ok(!!fatEntry);

--- a/t/testhelpers.cpp
+++ b/t/testhelpers.cpp
@@ -1,0 +1,55 @@
+/// @file t/testhelpers.cpp
+/// @brief Utilities for testing
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2021--2022 Christopher White
+
+#include "smallcxx/test.hpp"
+
+#include "testhelpers.hpp"
+
+#if BUILD_GLOBSTARI
+
+TEST_FILE
+
+#include "smallcxx/globstari.hpp"
+
+void
+compare_sequence(const std::set<smallcxx::glob::Path>& got,
+                 const std::vector<smallcxx::glob::Path>& expectedPaths,
+                 const char *func, const size_t line)
+{
+    // INFO log level so it will appear by default --- otherwise we don't know
+    // which test failed.
+    LOG_F(INFO, "Checking %s():%zu", func, line);
+
+    cmp_ok(got.size(), ==, expectedPaths.size());
+    size_t idx = 0;
+    for(auto it = got.cbegin();
+            (it != got.cend()) && (idx < expectedPaths.size());
+            ++it, ++idx) {
+        const auto& got = *it;
+        const auto& expected = expectedPaths[idx];
+        const auto where = got.rfind(expected);
+
+        LOG_F(SNOOP, "got [%s], expected [%s]", got.c_str(), expected.c_str());
+        cmp_ok(where, !=, got.npos);
+    }
+} // compare_sequence()
+
+smallcxx::IProcessEntry::Status
+SaveEntries::operator()(const std::shared_ptr<smallcxx::Entry>& entry)
+{
+    LOG_F(TRACE, "Found %s", entry->canonPath.c_str());
+    found.insert(entry->canonPath);
+    foundEntries[entry->canonPath] = entry;
+    return IProcessEntry::Status::Continue;
+}
+
+void
+SaveEntries::ignored(const std::shared_ptr<smallcxx::Entry>& entry)
+{
+    LOG_F(TRACE, "Found %s", entry->canonPath.c_str());
+    ignoredPaths.insert(entry->canonPath);
+    ignoredEntries[entry->canonPath] = entry;
+}
+#endif // BUILD_GLOBSTARI

--- a/t/testhelpers.hpp
+++ b/t/testhelpers.hpp
@@ -1,0 +1,45 @@
+/// @file t/testhelpers.hpp
+/// @brief Utilities for testing
+/// @author Christopher White <cxwembedded@gmail.com>
+/// @copyright Copyright (c) 2021--2022 Christopher White
+
+#ifndef TESTHELPERS_HPP_
+#define TESTHELPERS_HPP_
+
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#if BUILD_GLOBSTARI
+#include "smallcxx/globstari.hpp"
+
+/// Test if @p got matches @p expectedPaths.
+void
+compare_sequence(const std::set<smallcxx::glob::Path>& got,
+                 const std::vector<smallcxx::glob::Path>& expectedPaths,
+                 const char *func, const size_t line);
+
+/// Save filenames traversed.
+/// For testing globbing on disk.
+class SaveEntries: public smallcxx::IProcessEntry
+{
+public:
+    using EntryMap =
+        std::map<smallcxx::glob::Path, std::shared_ptr<smallcxx::Entry> >;
+    std::set<smallcxx::glob::Path> found;
+    EntryMap foundEntries;
+    std::set<smallcxx::glob::Path> ignoredPaths;
+    EntryMap ignoredEntries;
+
+    IProcessEntry::Status
+    operator()(const std::shared_ptr<smallcxx::Entry>& entry) override;
+
+    void
+    ignored(const std::shared_ptr<smallcxx::Entry>& entry) override;
+
+}; // SaveEntries
+
+#endif // BUILD_GLOBSTARI
+
+#endif // TESTHELPERS_HPP_


### PR DESCRIPTION
- Add a flag that `readDir()` can set in `Entry` to indicate the entry should be processed even if it otherwise be `.eignore`d.
- Add a flag in Entry that globstari sets to indicate whether an entry was ignored.

Fixes #33.