### PR TITLE
PRINT/PRINTERR: add tests and fix docs

### DIFF
--- a/include/smallcxx/logging.hpp
+++ b/include/smallcxx/logging.hpp
@@ -103,9 +103,6 @@ void vlogMessage(const std::string& domain,
 /// Main logging macro.  A newline will be appended to the message.
 /// Usage example: `LOG_F(INFO, "foo %s", some_string);`
 ///
-/// When using #LOG_PRINT (print to stdout) and #LOG_PRINTERR (print to stderr),
-/// @p format must be a string literal.
-///
 /// @note `LOG_F(SILENT, ...)` is forbidden.
 ///
 /// @param[in] level - the log level.  A `LOG_FOO` constant minus `LOG_`.

--- a/t/varying-log-s.cpp
+++ b/t/varying-log-s.cpp
@@ -22,8 +22,8 @@ main()
     LOG_F(PEEK, "peek1");
     LOG_F(SNOOP, "snoop1");
 
-    LOG_F(PRINT, "print1");
-    LOG_F(PRINTERR, "printerr1");
+    LOG_F(PRINT, "print%d", 1);
+    LOG_F(PRINTERR, "printerr%d", 1);
 
     // Change the default, if $LOG_LEVELS includes a `*:N` term
     setVerbosityFromEnvironment("LOG_LEVELS");
@@ -38,8 +38,8 @@ main()
     LOG_F(PEEK, "peek2");
     LOG_F(SNOOP, "snoop2");
 
-    LOG_F(PRINT, "print2");
-    LOG_F(PRINTERR, "printerr2");
+    LOG_F(PRINT, "print%d", 2);
+    LOG_F(PRINTERR, "printerr%d", 2);
 
     return 0;
 }


### PR DESCRIPTION
- Document that you can use printf formatting with LOG_PRINT{,ERR}
- Update PRINT{,ERR} tests to make use of that fact

Fixes #36 